### PR TITLE
Update update-binary

### DIFF
--- a/META-INF/com/google/android/update-binary
+++ b/META-INF/com/google/android/update-binary
@@ -110,7 +110,7 @@ image_size_check() {
   e2fsck -yf $1
   curBlocks=`e2fsck -n $1 2>/dev/null | grep $1 | cut -d, -f3 | cut -d\  -f2`;
   curUsedM=`echo "$curBlocks" | cut -d/ -f1`
-  curSizeM=`echo "$curBlocks" | cut -d/ -f1`
+  curSizeM=`echo "$curBlocks" | cut -d/ -f2`
   curFreeM=$(((curSizeM - curUsedM) * 4 / 1024))
   curUsedM=$((curUsedM * 4 / 1024 + 1))
   curSizeM=$((curSizeM * 4 / 1024))


### PR DESCRIPTION
`curFreeM` will be always = 0 because Output of `curUsedM` & `curSizeM` is same.    
Also look Here : https://github.com/topjohnwu/magisk-module-template/commit/6fd89d800eae3d6a14ec38c828d92d6f85a5bd2c